### PR TITLE
ステージ選択画面実装 デザインは改善の余地あり

### DIFF
--- a/src/page/StagePage/StagePage.js
+++ b/src/page/StagePage/StagePage.js
@@ -1,11 +1,30 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import styles from "./StagePage.module.css";
+
+function StageButton(props) {
+    return (
+        <Link to={'/game/'}>
+            <button className={props.className}>PUSH</button>
+        </Link>
+    )
+}
 
 export default function StagePage() {
     return (
         <>
-            <h1>StagePage</h1>
-            <div>
+            <div className={styles.stages}>
+                <h1 className='title'>ステージ選択</h1>
+                <div className={styles.buttons1}>
+                    <StageButton className={styles.topleft}/>
+                    <StageButton className={styles.topcenter}/>
+                    <StageButton className={styles.topright}/>
+                </div>
+                <div className={styles.buttons2}>
+                    <StageButton className={styles.bottomleft}/>
+                    <StageButton className={styles.bottomcenter}/>
+                    <StageButton className={styles.bottomright}/>
+                </div>
                 <Link to={'/game/'}>ゲーム画面へ</Link>
             </div>
         </>

--- a/src/page/StagePage/StagePage.module.css
+++ b/src/page/StagePage/StagePage.module.css
@@ -1,0 +1,59 @@
+.buttons1 {
+	display: flex;
+	justify-content: space-evenly;
+	margin-bottom: 5vw;
+}
+
+.buttons2 {
+	display: flex;
+	justify-content: space-evenly;
+}
+
+.stages {
+	background: #dee4f4;
+	height:100vh;
+	padding-top: 30px;
+;
+}
+
+.topleft {
+	width: 20vw;
+	height: 20vw;
+	background: #a7e2e1;
+	border-radius: 10px;
+}
+
+.topcenter {
+	width: 20vw;
+	height: 20vw;
+	background: #42c0a6;
+	border-radius: 10px;
+}
+
+.topright {
+	width: 20vw;
+	height: 20vw;
+	background: #B83D77;
+	border-radius: 10px;
+}
+
+.bottomleft {
+	width: 20vw;
+	height: 20vw;
+	background: #777528;
+	border-radius: 10px;
+}
+
+.bottomcenter {
+	width: 20vw;
+	height: 20vw;
+	background: #D98CC6;
+	border-radius: 10px;
+}
+
+.bottomright {
+	width: 20vw;
+	height: 20vw;
+	background: #78286F;
+	border-radius: 10px;
+}


### PR DESCRIPTION
# 概要
ステージ画面実装。ボタンの行き先は全部ゲームページになってる。

# やったこと
-[] レイアウト
-[] 画面遷移

# 確認方法
-[] ステージ選択画面まで行って、ボタンで画面遷移ができる

# レビューの方法
git fetch origin pull/23/head:request23
git checkout request23
npm i
npm start or yarn start

Close #11 